### PR TITLE
Added a dns workaround for ipv6 (see issue#25)

### DIFF
--- a/app.js
+++ b/app.js
@@ -12,6 +12,12 @@ if (local.length == 0) {
 	process.exit();
 }
 
+const ipv = local.getItem('ipv');
+if (ipv.trim() === '6') {
+	console.log("You setup ipv6 connectivity. We need to apply a workaround for dns resolution.");
+	require('./ipv6-dns-workaround');
+}
+
 // host names without domain
 const servers = local.getItem('servers').split(',');
 const home = local.getItem('home');
@@ -106,7 +112,7 @@ const initialize = () => {
 				SecNode.getNetworks(null, (err, nets) => {
 					ident.nets = nets;
 					socket.emit('initnode', ident, () => {
-						//only pass email and nets on init.  
+						//only pass email and nets on init.
 						delete ident.email;
 						delete ident.nets;
 					});
@@ -182,7 +188,7 @@ const setSocketEvents = () => {
 			case 'networks':
 				SecNode.getNets(data);
 				break;
-				
+
 			case 'changeServer':
 				switchServer(data.server);
 				break;
@@ -230,4 +236,3 @@ const conCheck = () => {
 SecNode.socket = socket;
 SecNode.initialize();
 conCheck();
-

--- a/ipv6-dns-workaround.js
+++ b/ipv6-dns-workaround.js
@@ -1,0 +1,7 @@
+'use strict';
+
+const dns = require('dns'), {lookup} = dns;
+dns.lookup = function(name, opts, cb) {
+  if (typeof cb !== 'function') return lookup(name, {verbatim:true}, opts);
+  return lookup(name, Object.assign({verbatim:true}, opts), cb);
+};


### PR DESCRIPTION
Basically node.js will reorder the systems return of dns resolution.
This fix applies the `verbatim` flag to nodes dns resolution which prevents this reordering.