### PR TITLE
fix typo on no z address error message

### DIFF
--- a/SecNodeTracker.js
+++ b/SecNodeTracker.js
@@ -108,7 +108,7 @@ class SecNode {
         this.zenrpc.z_listaddresses()
           .then((results) => {
             if (results.length == 0) {
-              console.log("No private address found. Please create one using 'zen_cli z_getnewaddress' and send at least 1 ZEN for challenges split into 4 or more transactions");
+              console.log("No private address found. Please create one using 'zen-cli z_getnewaddress' and send at least 1 ZEN for challenges split into 4 or more transactions");
               return cb(null)
             }
             let called = false;


### PR DESCRIPTION
The error message currently says 

```
No private address found. Please create one using 'zen_cli z_getnewaddress' and send at least 1 ZEN for challenges split into 4 or more transactions
```

Syntax for the command is wrong

```
root@sn6:~# zen_cli z_getnewaddress
bash: zen_cli: command not found
```

Correct syntax is 

```
root@sn6:~# zen-cli z_getnewaddress
```